### PR TITLE
feat: allow json serializer to generate a json array

### DIFF
--- a/plugins/serializers/json/README.md
+++ b/plugins/serializers/json/README.md
@@ -40,6 +40,9 @@ The `json` output data format converts metrics into JSON documents.
   ## can contain wildcards.
   #json_nested_fields_include = []
   #json_nested_fields_exclude = []
+
+  ## Enable json array output 
+  # output_json_array
 ```
 
 ## Examples
@@ -99,6 +102,42 @@ reference the documentation for the specific plugin.
 }
 ```
 
+When batch forma is used and the configuration option output_json_array
+is enabled the following metrics array form we be used.
+
+```json
+{
+    "metrics": [
+        {
+            "fields": {
+                "field_1": 30,
+                "field_2": 4,
+                "field_N": 59,
+                "n_images": 660
+            },
+            "name": "docker",
+            "tags": {
+                "host": "raynor"
+            },
+            "timestamp": 1458229140
+        },
+        {
+            "fields": {
+                "field_1": 30,
+                "field_2": 4,
+                "field_N": 59,
+                "n_images": 660
+            },
+            "name": "docker",
+            "tags": {
+                "host": "raynor"
+            },
+            "timestamp": 1458229140
+        }
+    ]
+}
+```
+
 ## Transformations
 
 Transformations using the [JSONata standard](https://jsonata.org/) can be specified with
@@ -107,7 +146,8 @@ metric in the standard-form above.
 
 **Note**: There is a difference in batch and non-batch serialization mode!
 The former adds a `metrics` field containing the metric array, while the later
-serializes the metric directly.
+serializes the metric directly. If a configuration option output_json_array is enabled
+then the former will skip adding a `metrics` field and will contain only a metric array.
 
 **Note**: Please note that the JSONata support is limited to version 1.5.4 due
 to the underlying library used by Telegraf. When using the online playground

--- a/plugins/serializers/json/json.go
+++ b/plugins/serializers/json/json.go
@@ -86,17 +86,18 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 		objects = append(objects, m)
 	}
  	
-	var obj interface{}
-	var err error
- 	var serialized []byte
-
 	if s.OutputJSONArray == bool(true) {
 		serialized, err := json.Marshal(objects)
+		if err != nil {
+			return []byte{}, err
+		}
+		serialized = append(serialized, '\n')
+		return serialized, nil
 	} else {
+		var obj interface{}
 		obj = map[string]interface{}{
 			"metrics": objects,
 		}
-
 		if s.Transformation != "" {
 			var err error
 			if obj, err = s.transform(obj); err != nil {
@@ -107,14 +108,12 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 			}
 		}
 		serialized, err := json.Marshal(obj)
+		if err != nil {
+			return []byte{}, err
+		}
+		serialized = append(serialized, '\n')
+		return serialized, nil
         }
-
-	if err != nil {
-		return []byte{}, err
-	}
-	serialized = append(serialized, '\n')
-
-	return serialized, nil
 
 }
 

--- a/plugins/serializers/json/json.go
+++ b/plugins/serializers/json/json.go
@@ -86,7 +86,7 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 		objects = append(objects, m)
 	}
 
-	if OutputJSONArray == bool(true) {
+	if s.OutputJSONArray == bool(true) {
 		serialized, err := json.Marshal(objects)
 	} else {
 		var obj interface{}

--- a/plugins/serializers/json/json.go
+++ b/plugins/serializers/json/json.go
@@ -85,11 +85,14 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 		m := s.createObject(metric)
 		objects = append(objects, m)
 	}
+ 	
+	var obj interface{}
+	var err error
+ 	var serialized []byte
 
 	if s.OutputJSONArray == bool(true) {
 		serialized, err := json.Marshal(objects)
 	} else {
-		var obj interface{}
 		obj = map[string]interface{}{
 			"metrics": objects,
 		}
@@ -106,13 +109,13 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 		serialized, err := json.Marshal(obj)
         }
 
-
 	if err != nil {
 		return []byte{}, err
 	}
 	serialized = append(serialized, '\n')
 
 	return serialized, nil
+
 }
 
 func (s *Serializer) createObject(metric telegraf.Metric) map[string]interface{} {

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -120,6 +120,9 @@ type Config struct {
 	JSONNestedFieldInclude []string `toml:"json_nested_fields_include"`
 	JSONNestedFieldExclude []string `toml:"json_nested_fields_exclude"`
 
+	// Enable json array output
+	OutputJSONArray bool `toml:"output_json_array"`
+
 	// Include HEC routing fields for splunkmetric output
 	HecRouting bool `toml:"hec_routing"`
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
On batch serialization mode the JSON former adds a metrics field containing the metric array (JSON object containing a key with an array of objects)
```
{
    "metrics": [
        {
            "fields": {
                "field_1": 30,
                "field_2": 4,
                "field_N": 59,
                "n_images": 660
            },
            "name": "docker",
            "tags": {
                "host": "raynor"
            },
            "timestamp": 1458229140
        },
        {
            "fields": {
                "field_1": 30,
                "field_2": 4,
                "field_N": 59,
                "n_images": 660
            },
            "name": "docker",
            "tags": {
                "host": "raynor"
            },
            "timestamp": 1458229140
        }
    ]
}
```
The change adds a configuration option **output_json_array** which outputs a JSON array:
```
[
  {
      "fields": {
          "field_1": 30,
          "field_2": 4,
          "field_N": 59,
          "n_images": 660
      },
      "name": "docker",
      "tags": {
          "host": "raynor"
      },
      "timestamp": 1458229140
  },
  {
      "fields": {
          "field_1": 30,
          "field_2": 4,
          "field_N": 59,
          "n_images": 660
      },
      "name": "docker",
      "tags": {
          "host": "raynor"
      },
      "timestamp": 1458229140
  }
]
```
That will allow some database servers like Clickhouse to ingesting the data in a batches.
Sample usage:
```
      [[outputs.http]]
        url = "http://clickhouse.server.com:8123/?query=INSERT%20INTO%20_TABLENAME_%20FORMAT%20JSONEachRow"
        username = "sample_username"
        password = "sample_password"
        method = "POST"
        data_format = "json"
        output_json_array = true
        [outputs.http.headers]
          Content-Type = "application/json"
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
